### PR TITLE
Complete zh-HANS and zh-HANT translations to 100%

### DIFF
--- a/Code/Localization/zh-HANS.json
+++ b/Code/Localization/zh-HANS.json
@@ -138,5 +138,7 @@
     "Traffic.Tooltip.Tools[LaneConnector][RoadOnly]": "道路车道连线工具",
     "Traffic.Tooltip.Tools[LaneConnector][TrackOnly]": "轨道车道连线工具",
     "Traffic.Tooltip.Tools[LaneConnector][SharedLaneOnly]": "任意车道连接点类型",
-    "Traffic.Tooltip.Tools[LaneConnector][RoadOnly, MakeUnsafe]": "不安全的车道连线"
+    "Traffic.Tooltip.Tools[LaneConnector][RoadOnly, MakeUnsafe]": "不安全的车道连线",
+    "Traffic.Tooltip.Tools[LaneConnector][BikeOnly, MakeUnsafe]": "不安全的自行车道连线",
+    "Options.OPTION[Traffic.Traffic.Mod/PrioritiesToggleDisplayMode/binding]": "切换优先级显示模式"
 }

--- a/Code/Localization/zh-HANT.json
+++ b/Code/Localization/zh-HANT.json
@@ -138,5 +138,7 @@
     "Traffic.Tooltip.Tools[LaneConnector][RoadOnly]": "道路車道連線工具",
     "Traffic.Tooltip.Tools[LaneConnector][TrackOnly]": "軌道車道連線工具",
     "Traffic.Tooltip.Tools[LaneConnector][SharedLaneOnly]": "任意車道連接點類型",
-    "Traffic.Tooltip.Tools[LaneConnector][RoadOnly, MakeUnsafe]": "不安全的車道連線"
+    "Traffic.Tooltip.Tools[LaneConnector][RoadOnly, MakeUnsafe]": "不安全的車道連線",
+    "Traffic.Tooltip.Tools[LaneConnector][BikeOnly, MakeUnsafe]": "不安全的自行車道連線",
+    "Options.OPTION[Traffic.Traffic.Mod/PrioritiesToggleDisplayMode/binding]": "切換優先權顯示模式"
 }


### PR DESCRIPTION
### Summary

Completes the Simplified Chinese (zh-HANS) and Traditional Chinese (zh-HANT) translations, bringing coverage from 98.6% to 100%.

### Changes

- Added 2 missing entries to both locale files:
  - `Traffic.Tooltip.Tools[LaneConnector][BikeOnly, MakeUnsafe]` → 不安全的自行车道连线 / 不安全的自行車道連線
  - `Options.OPTION[...PrioritiesToggleDisplayMode/binding]` → 切换优先级显示模式 / 切換優先權顯示模式